### PR TITLE
fix: recognize the wrong Time obj from a log data [#4]

### DIFF
--- a/LogObjParser/LogObjParser.py
+++ b/LogObjParser/LogObjParser.py
@@ -2,9 +2,6 @@ from LogObjParser.handle_file import extract_log_from_path, output_obj_to_csv
 from LogObjParser.parser import parse_log_data
 
 
-# SUB_SIGN = "   #spec#   "  # 각 obj 를 인식 후 해당 obj 자리 제거를 위한 string
-
-
 class LogParser:
     """ Object parsing log str obj """
 

--- a/LogObjParser/handle_pattern.py
+++ b/LogObjParser/handle_pattern.py
@@ -36,6 +36,10 @@ JUST_FILE = re.compile(r"([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+")
 JUST_EMACS_TEMP_FILE = re.compile(r"([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10}~)(\s|$|:)+")
 JUST_VIM_TEMP_FILE = re.compile(r"(#[@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10}#)(\s|$|:)+")
 
+""" Time Regrex Pattern for validation """
+SUBTRACT_TIME_PATTERN = "(?<sub_time>0{3,}:0{2,}:|0{3,}:|%{MAC}([:]\d*)*)"
+SUBTRACT_TIME_GROK = Grok(SUBTRACT_TIME_PATTERN)
+
 
 def upload_grok_obj():
     """ Returns grok objects after converting them to a dict """


### PR DESCRIPTION
- 아래와 같이 time obj 를 잘못 인식
    - {"address": "0000:00:06.2} -> "TIME": '00:00:06.2'
    - is set to 000:00:00:00.000 -> "TIME": '00:00:00:00'
    - 02:42:ac:ff:fe:11:00:02 -> "TIME": '11:00:02'
- time obj 를 인식하기 전에 subtract from a log
    - subtract from a log 를 위한 custom grok pattern 생성
    - get_time_objs 함수 추가