### PR TITLE
fix: recognize the wrong File Path obj from a log data [#6]

### DIFF
--- a/LogObjParser/handle_pattern.py
+++ b/LogObjParser/handle_pattern.py
@@ -6,7 +6,7 @@ TIME_PATTERN = "(?<time>%{TIME:time}([+]([0-9]*))?)"
 DATE_PATTERN = "(?<date>%{YEAR}[/-]%{MONTHNUM}[/-]%{MONTHDAY}[T ]|%{DAY}([\S])? %{MONTHDAY} %{MONTH} %{YEAR}|%{MONTHDAY} %{MONTH} %{YEAR}|%{MONTH} %{YEAR}|%{YEAR} %{MONTH} %{MONTHDAY}|%{DAY} %{MONTH} %{MONTHDAY}|%{MONTH} %{MONTHDAY})"  # Custom Date pattern : 날짜 뒤 T 까지 추출
 URI_PATTERN = "(?<url>%{URI}|GET %{PATH}[\S]*|POST %{PATH}[\S]*)"
 IP_PATTERN = "(?<ip>%{HOSTNAME}[/:]%{IPV4}([:]%{POSINT})?|[/]%{IPV4}([:]%{POSINT})?|[^-]%{IPV4}([:]%{POSINT})?)"  # 마지막 pattern 은 수정이 필요 : =155.~~ -를 제외한 특수문자를 다 가져옴.
-PATH_PATTERN = "(?<path>[^A-Za-z]%{PATH}([ ]([\d]*))?)"
+PATH_PATTERN = "(?<path>[^A-Za-z]%{PATH})"
 
 TIME_GROK = Grok(TIME_PATTERN)
 DATE_GROK = Grok(DATE_PATTERN)

--- a/LogObjParser/parser.py
+++ b/LogObjParser/parser.py
@@ -47,8 +47,9 @@ def get_all_objs(log: str, obj_type: str):
     if is_objs:
         for is_obj in is_objs:
             if obj_type == "PATH":
+                # findall 로 리턴된 튜플 안에서 0번째 path 선택 & file path 처음 및 마지막 필요 없는 str obj 제거
                 return_obj_list.append(
-                    is_obj[0][1:].rstrip())  # findall 로 리턴된 튜플 안에서 1번째 path 가 가장 정확 (거의 대부분 앞에 =, " " 등 삭제)
+                    is_obj[0][1:].strip(',.:= '))
             elif obj_type == "IP":
                 is_ip = is_obj[0].strip()
                 if is_ip[0] == '"' or is_ip[0] == "=":  # IP 의 경우 string 첫번째 문자가 ", = 경우가 있어 제거


### PR DESCRIPTION
아래 2가지 문제를 해결
1. 아래 예시와 같이 잘못된 file path obj 를 인식
- '/proc/sys/net/core/somaxconn: 128'
    - 128: 서버 소켓에서 accept()를 기다리는 소켓 개수 (제한) 으로
    파일 내 코드 라인(줄)을 의미X
- /home/james/hadoop-2.7.4/hdfs/data/current: 13ms 를 다음처럼 인식
    - '/home/james/hadoop-2.7.4/hdfs/data/current: 13'
2. 아래 예시와 같이 필요없는 str obj 포함
- '=/home/james/hadoop-2.7.4/hdfs/data/current,'
- '/home/james/hadoop-2.7.4/hdfs/data/current...'